### PR TITLE
Fix professor edit route handling

### DIFF
--- a/routes/profesores.js
+++ b/routes/profesores.js
@@ -6,10 +6,10 @@ const profesoresController = require('../controllers/profesoresController');
 router.get('/', profesoresController.index);
 router.get('/create', profesoresController.create);
 router.post('/', profesoresController.store);
-router.get('/:id', profesoresController.show);
 router.get('/:id/edit', profesoresController.edit);
 router.put('/:id', profesoresController.update);
 router.delete('/:id', profesoresController.destroy);
+router.get('/:id', profesoresController.show);
 
 // Rutas para horarios de profesores
 router.post('/:id/horarios', profesoresController.addHorario);


### PR DESCRIPTION
## Summary
- reorder professor routes so `/profesores/:id/edit` is evaluated before `/profesores/:id`

## Testing
- `npm test --silent` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68671df73a508326bf3ae6bd6b1519a7